### PR TITLE
fix GIAI-96 header and CPI96 getType()

### DIFF
--- a/epc/cpi/cpi96.js
+++ b/epc/cpi/cpi96.js
@@ -55,7 +55,7 @@ class Cpi96 extends Epc {
 	}
 
 	getType() {
-		return Type.GPI96;
+		return Type.CPI96;
 	}
 
 	static fromTagURI(uri) {
@@ -112,16 +112,16 @@ class Cpi96 extends Epc {
 	}
 
 	getCpi() {
-        let partition = Cpi96.PARTITIONS[this.getPartition()];
-        let companyPrefix = super.getSegmentString(partition.a);
+		let partition = Cpi96.PARTITIONS[this.getPartition()];
+		let companyPrefix = super.getSegmentString(partition.a);
 		let asset = super.getSegment(partition.b);
 		return companyPrefix + asset;
 	}
 
 	setCpi(cpi) { // ean
-        let partition = Cpi96.PARTITIONS[this.getPartition()];  
+		let partition = Cpi96.PARTITIONS[this.getPartition()];
 		super.setSegment(cpi.substring(0, partition.a.digits), partition.a);
-        let tmp = partition.a.digits + partition.b.digits;
+		let tmp = partition.a.digits + partition.b.digits;
 		super.setSegment(cpi.substring(partition.a.digits, tmp), partition.b);
 		return this;
 	}

--- a/epc/giai/giai96.js
+++ b/epc/giai/giai96.js
@@ -17,7 +17,7 @@
  
 class Giai96 extends Epc {
 
-	static EPC_HEADER = 0x52;
+	static EPC_HEADER = 0x34;
 
 	static TOTAL_BITS = 96;
 	static PARTITION_OFFSET = 11;
@@ -108,7 +108,7 @@ class Giai96 extends Epc {
 
 	getGiai() {
 		let partition = Giai96.PARTITIONS[this.getPartition()];
-        let companyPrefix = super.getSegmentString(partition.a);
+		let companyPrefix = super.getSegmentString(partition.a);
 		let asset = super.getSegment(partition.b);
 		return companyPrefix + asset;
 	}
@@ -116,7 +116,7 @@ class Giai96 extends Epc {
 	setGiai(giai) {
 		let partition = Giai96.PARTITIONS[this.getPartition()];  
 		super.setSegment(giai.substring(0, partition.a.digits), partition.a);
-        let tmp = partition.a.digits + partition.b.digits;
+		let tmp = partition.a.digits + partition.b.digits;
 		super.setSegment(giai.substring(partition.a.digits, tmp), partition.b);
 		return this;
 	}

--- a/epc/type.js
+++ b/epc/type.js
@@ -4,7 +4,7 @@
 */
 
 class Type {
-
+  static CPI96    = "CPI-96";
   static SGTIN96  = "SGTIN-96";
   static SGTIN198 = "SGTIN-198";
   static SSCC96   = "SSCC-96";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epc-tds",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "directories": {
     "doc": "doc"
   },


### PR DESCRIPTION
fix: Header for GIAI-96 is 00110100, which is 0x34. 52 is the decimal
fix: CPI96 was missing from type.js, and CPI96.getType() was returning the wrong value